### PR TITLE
Upgrade wascc-codec to v0.3.5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ categories = ["wasm", "api-bindings"]
 travis-ci = { repository = "wascc/wascc-actor", branch = "master" }
 
 [dependencies]
-wascc-codec = "0.3.4"
+wascc-codec = "0.3.5"
 wapc-guest = "0.1.1"
 prost = "0.6.1"
 serde_json = "1.0.46"


### PR DESCRIPTION
Closes #1.

```console
% cargo build
    Updating crates.io index
  Downloaded wascc-codec v0.3.5
   Compiling autocfg v1.0.0
   Compiling fixedbitset v0.2.0
   Compiling multimap v0.8.0
   Compiling which v3.1.0
   Compiling prost-build v0.6.1
   Compiling indexmap v1.3.2
   Compiling petgraph v0.5.0
   Compiling wascc-codec v0.3.5
   Compiling wascc-actor v0.1.1 (/Users/gtb273/wrk/src/github.com/wascc/wascc-actor)
    Finished dev [unoptimized + debuginfo] target(s) in 7.78s
% cargo test
   Compiling wascc-actor v0.1.1 (/Users/gtb273/wrk/src/github.com/wascc/wascc-actor)
    Finished test [unoptimized + debuginfo] target(s) in 0.51s
     Running target/debug/deps/wascc_actor-f804edd2b04b484a

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

   Doc-tests wascc-actor

running 1 test
test src/lib.rs -  (line 26) ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```