### PR TITLE
#7 - Incomplete rustdocs

### DIFF
--- a/src/events.rs
+++ b/src/events.rs
@@ -1,8 +1,27 @@
+// Copyright 2015-2019 Capital One Services, LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! # Errors
+//!
+//! This module contains types and utility functions for eventstream handling.
+
 use crate::Result;
+use codec::eventstreams::*;
+use codec::{deserialize, serialize};
 use std::collections::HashMap;
 use wapc_guest::host_call;
-use wascc_codec::eventstreams::*;
-use wascc_codec::{deserialize, serialize};
+use wascc_codec as codec;
 
 const CAPID_EVENTS: &str = "wascc:eventstreams";
 

--- a/src/extras.rs
+++ b/src/extras.rs
@@ -1,6 +1,27 @@
+// Copyright 2015-2019 Capital One Services, LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! # Errors
+//!
+//! This module contains types and utility functions for extras handling.
+//! Extras are utility functions that illustrate how actors can interact
+//! with the host runtime.
+
+use codec::extras::*;
+use codec::{deserialize, serialize};
 use wapc_guest::host_call;
-use wascc_codec::extras::*;
-use wascc_codec::{deserialize, serialize};
+use wascc_codec as codec;
 
 const CAPID_EXTRAS: &str = "wascc:extras";
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,11 +28,15 @@
 //!
 //! use actor::prelude::*;
 //!
+//! #[macro_use]
+//! extern crate serde_json;
+//!
 //! actor_handlers!{ codec::http::OP_HANDLE_REQUEST => hello_world,
 //!                  codec::core::OP_HEALTH_REQUEST => health }
 //!
-//! pub fn hello_world(_req: codec::http::Request) -> HandlerResult<codec::http::Response> {
-//!   Ok(codec::http::Response::ok())
+//! fn hello_world(_payload: codec::http::Request) -> CallResult {
+//!     let result = json!({ "hello": "world", "data": 21});
+//!     Ok(serialize(codec::http::Response::json(result, 200, "OK"))?)
 //! }
 //!
 //! pub fn health(_req: codec::core::HealthRequest) -> HandlerResult<()> {

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -1,9 +1,29 @@
+// Copyright 2015-2019 Capital One Services, LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! # Errors
+//!
+//! This module contains is the default host logger implementation.
+//! wapc_guest provides the host shim.
+
 use crate::Result;
+use codec::logging::*;
+use codec::serialize;
 use log::{Metadata, Record};
 use std::sync::{Arc, RwLock};
 use wapc_guest::host_call;
-use wascc_codec::logging::*;
-use wascc_codec::serialize;
+use wascc_codec as codec;
 
 /// The reserved capability ID for the logging functionality
 pub const CAPID_LOGGING: &str = "wascc:logging";

--- a/src/objectstore.rs
+++ b/src/objectstore.rs
@@ -1,13 +1,33 @@
+// Copyright 2015-2019 Capital One Services, LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! # Errors
+//!
+//! This module contains tghe object store client interface through which actor modules
+//! access a bound `wascc:blobstore` capability provider
+
 use crate::Result;
-use wapc_guest::host_call;
-use wascc_codec::blobstore::Blob;
-use wascc_codec::blobstore::Container;
-use wascc_codec::blobstore::{BlobList, FileChunk, StreamRequest, Transfer};
-use wascc_codec::blobstore::{
+use codec::blobstore::Blob;
+use codec::blobstore::Container;
+use codec::blobstore::{BlobList, FileChunk, StreamRequest, Transfer};
+use codec::blobstore::{
     OP_CREATE_CONTAINER, OP_GET_OBJECT_INFO, OP_LIST_OBJECTS, OP_REMOVE_CONTAINER,
     OP_REMOVE_OBJECT, OP_START_DOWNLOAD, OP_START_UPLOAD, OP_UPLOAD_CHUNK,
 };
-use wascc_codec::{deserialize, serialize};
+use codec::{deserialize, serialize};
+use wapc_guest::host_call;
+use wascc_codec as codec;
 
 const CAPID_BLOBSTORE: &str = "wascc:blobstore";
 

--- a/src/untyped.rs
+++ b/src/untyped.rs
@@ -14,8 +14,8 @@
 
 //! # Message Broker
 //!
-//! This module contains the message broker client interface through which actor modules access
-//! a bound `wascc:messaging` capability provider
+//! This module contains an untyped host binding implementation to allow for
+//! third party expansion by the community.
 
 use wapc_guest::host_call;
 


### PR DESCRIPTION
Added missing module descriptions. Synchronized root module doc with example provided at https://wascc.dev/tutorials/first-actor/create_project/. Added missing use wascc_codec as codec; statements and simplified affected use statements.